### PR TITLE
ci: factor Hugo install into a composite action

### DIFF
--- a/.github/actions/install-hugo/action.yml
+++ b/.github/actions/install-hugo/action.yml
@@ -1,0 +1,25 @@
+name: Install Hugo extended
+description: Download, SHA-256 verify, and install Hugo extended on Linux runners.
+
+inputs:
+  version:
+    description: Hugo version without leading v (e.g. 0.160.1).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download and verify Hugo extended
+      shell: bash
+      env:
+        HUGO_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        TARBALL="hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+        curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${TARBALL}" -o "${TARBALL}"
+        curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt" -o hugo_checksums.txt
+        grep "${TARBALL}" hugo_checksums.txt | sha256sum -c -
+        tar xzf "${TARBALL}" hugo
+        sudo mv hugo /usr/local/bin/hugo
+        rm "${TARBALL}" hugo_checksums.txt
+        hugo version

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -23,15 +23,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Install Hugo extended
-        run: |
-          TARBALL="hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-          curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${TARBALL}" -o "${TARBALL}"
-          curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt" -o hugo_checksums.txt
-          grep "${TARBALL}" hugo_checksums.txt | sha256sum -c -
-          tar xzf "${TARBALL}" hugo
-          sudo mv hugo /usr/local/bin/hugo
-          rm "${TARBALL}" hugo_checksums.txt
-          hugo version
+        uses: ./.github/actions/install-hugo
+        with:
+          version: ${{ env.HUGO_VERSION }}
       - name: Install brotli
         run: sudo apt-get update && sudo apt-get install -y brotli
       - name: Enforce performance budgets
@@ -47,15 +41,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Install Hugo extended
-        run: |
-          TARBALL="hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-          curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${TARBALL}" -o "${TARBALL}"
-          curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt" -o hugo_checksums.txt
-          grep "${TARBALL}" hugo_checksums.txt | sha256sum -c -
-          tar xzf "${TARBALL}" hugo
-          sudo mv hugo /usr/local/bin/hugo
-          rm "${TARBALL}" hugo_checksums.txt
-          hugo version
+        uses: ./.github/actions/install-hugo
+        with:
+          version: ${{ env.HUGO_VERSION }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '22'


### PR DESCRIPTION
## Summary

- Extracts the duplicated Hugo-install shell block from `perf.yml` into `.github/actions/install-hugo/action.yml` as a local composite action with a `version` input.
- Both `budget` and `lighthouse` jobs now call `uses: ./.github/actions/install-hugo` with `version: ${{ env.HUGO_VERSION }}`.
- No behavior change: same tarball URL, same `sha256sum -c` check, same `/usr/local/bin/hugo` install path. Added `set -euo pipefail` in the composite for slightly stricter failure semantics.

Closes #26.

## Test plan

- [ ] `budget` job passes (Hugo installed via composite action).
- [ ] `lighthouse` job passes (same).
- [ ] Cloudflare Pages preview deploys (unaffected by CI changes).