### PR TITLE
ci: pass URL via env to avoid script-injection pattern in http-verify

### DIFF
--- a/.github/workflows/http-verify.yml
+++ b/.github/workflows/http-verify.yml
@@ -41,4 +41,6 @@ jobs:
             || { echo "::error::curl on this runner lacks HTTP/3 support"; exit 2; }
 
       - name: Run http-verify
-        run: scripts/http-verify.sh '${{ inputs.url || 'https://blog.szypowi.cz/' }}'
+        env:
+          URL: ${{ inputs.url || 'https://blog.szypowi.cz/' }}
+        run: scripts/http-verify.sh "$URL"


### PR DESCRIPTION
## Summary

- `.github/workflows/http-verify.yml` previously interpolated `\${{ inputs.url }}` directly into a shell argument
- swap to `env: URL:` plus `"\$URL"` in the `run:` block so the runner treats the value as data, not code
- `scripts/http-verify.sh` already reads `\$1`, no script-side change needed

The trigger is `workflow_dispatch` only today, so impact is bounded - but the pattern is risky to keep around if the workflow ever gains an event-based trigger.

## Test plan

- [ ] Trigger via `gh workflow run http-verify.yml` with the default URL, confirm green
- [ ] Trigger again with a payload-shaped override (`https://example.com'; echo INJECTED;'`) and confirm `INJECTED` does not appear in the runner log